### PR TITLE
Issue #128: Set up TravisCI to cache its local Maven repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: java
 sudo: required
 
+cache:
+  directories:
+  - .autoconf
+  - $HOME/.m2
+
 jdk:
   - oraclejdk8
 


### PR DESCRIPTION
Adding Maven dependencies caching to speed up build.

Signed-off-by: Spiros Petratos <spetratos@paypal.com>