### PR TITLE
Split staging repositories fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,18 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+        				<groupId>org.sonatype.plugins</groupId>
+        				<artifactId>nexus-staging-maven-plugin</artifactId>
+        				<version>1.6.8</version>
+        				<extensions>true</extensions>
+        				<configuration>
+              				<serverId>ossrh</serverId>
+          					<nexusUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</nexusUrl>
+          					<!-- update this with the correct id! -->
+          					<stagingProfileId>ee3714f400922</stagingProfileId>
+        				</configuration>
+      				</plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
- Adding Nexus Staging Maven Plugin;

See https://issues.sonatype.org/browse/OSSRH-38347:
Depending on the network infrastructure involved, a single
staging operation can appear to Nexus that it's coming from two
different IP address, which will cause Nexus to create two
separate staging repositories.

Signed-off-by: Spiros Petratos <spetratos@paypal.com>