### PR TITLE
Split staging repositories fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         				<extensions>true</extensions>
         				<configuration>
               				<serverId>ossrh</serverId>
-          					<nexusUrl>https://oss.sonatype.org/service/local/staging/deploy/maven2/</nexusUrl>
+          					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
           					<!-- update this with the correct id! -->
           					<stagingProfileId>ee3714f400922</stagingProfileId>
         				</configuration>


### PR DESCRIPTION
- Modifying the serverURL in the Nexus Staging Maven Plugin:
<nexusurl>https://oss.sonatype.org/</nexusurl>

Signed-off-by: Spiros Petratos <spetratos@paypal.com>