### PR TITLE
#111 Enabled adding property to empty file.

### DIFF
--- a/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/operations/EolHelper.java
+++ b/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/operations/EolHelper.java
@@ -15,6 +15,7 @@ public abstract class EolHelper {
      * Finds out what EOL character(s) are used by the specified text file.
      * If the specified file has no EOL characters null will be returned, and if more than
      * one type of EOL character(s) are used, the very first EOL occurrence will be returned.
+     * If the file is empty, it returns null.
      *
      * @param textFile file to be analyzed based on its EOL character(s)
      * @return  the very first occurrence of EOL used in the specified text file, or null,
@@ -28,6 +29,9 @@ public abstract class EolHelper {
         }
         if (!textFile.isFile()) {
             throw new IllegalArgumentException("Text file is not a file");
+        }
+        if (textFile.length() == 0) {
+            return null;
         }
         EolBufferedReader eolBufferedReader = null;
         try {

--- a/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/operations/properties/AddProperty.java
+++ b/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/operations/properties/AddProperty.java
@@ -127,7 +127,9 @@ public class AddProperty extends TransformationOperation<AddProperty> {
         TOExecutionResult result;
         try {
             String propertyToBeAdded = String.format("%s = %s", propertyName, propertyValue);
-            FileUtils.fileAppend(fileToBeChanged.getAbsolutePath(), EolHelper.findEolDefaultToOs(fileToBeChanged));
+            if (fileToBeChanged.length() != 0) {
+                FileUtils.fileAppend(fileToBeChanged.getAbsolutePath(), EolHelper.findEolDefaultToOs(fileToBeChanged));
+            }
             FileUtils.fileAppend(fileToBeChanged.getAbsolutePath(), propertyToBeAdded);
             String details = String.format("Property '%s' has been added and set to '%s' at '%s'", propertyName, propertyValue, getRelativePath());
             result = TOExecutionResult.success(this, details);

--- a/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/file/FindFilesTest.java
+++ b/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/file/FindFilesTest.java
@@ -407,7 +407,7 @@ public class FindFilesTest extends TransformationUtilityTestHelper {
         Assert.assertNotNull(executionResult.getValue());
 
         List<File> files = (List<File>) executionResult.getValue();
-        Assert.assertEquals(files.size(), 52);
+        Assert.assertEquals(files.size(), 53);
 
         Assert.assertTrue(files.contains(new File(transformedAppFolder, "src")));
         Assert.assertTrue(files.contains(new File(transformedAppFolder, "blah")));
@@ -430,7 +430,7 @@ public class FindFilesTest extends TransformationUtilityTestHelper {
         Assert.assertNotNull(executionResult.getValue());
 
         List<File> files = (List<File>) executionResult.getValue();
-        Assert.assertEquals(files.size(), 12);
+        Assert.assertEquals(files.size(), 13);
 
         Assert.assertTrue(files.contains(new File(transformedAppFolder, "/src/main/resources/more_yaml")));
         Assert.assertTrue(files.contains(new File(transformedAppFolder, "/src/main/resources/more_yaml/dogs.yaml")));

--- a/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/operations/EolHelperTest.java
+++ b/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/operations/EolHelperTest.java
@@ -34,6 +34,12 @@ public class EolHelperTest {
     }
 
     @Test
+    public void findEolForEmptyFileTest() throws IOException, URISyntaxException {
+        File file = new File(EolHelperTest.class.getResource("/test-app/src/main/resources/application-empty.properties").toURI());
+        Assert.assertEquals(EolHelper.findEol(file), null);
+    }
+
+    @Test
     public void removeEolTest() {
         Assert.assertEquals(EolHelper.removeEol(LINE1), "blah");
         Assert.assertEquals(EolHelper.removeEol(LINE2), "blah");

--- a/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/operations/properties/AddPropertyTest.java
+++ b/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/operations/properties/AddPropertyTest.java
@@ -20,6 +20,27 @@ import static org.testng.Assert.assertEquals;
 public class AddPropertyTest extends TransformationUtilityTestHelper {
 
     @Test
+    public void successAddToEmptyFile() throws IOException {
+        final String relativeFilePath = "/src/main/resources/application-empty.properties";
+        final String testKey = "testkey";
+        final String testValue = "testvalue";
+
+        AddProperty addProperty = new AddProperty().setPropertyName(testKey).setPropertyValue(testValue).relative(relativeFilePath);
+
+        TOExecutionResult executionResult = addProperty.execution(transformedAppFolder, transformationContext);
+        assertEquals(executionResult.getType(), TOExecutionResult.Type.SUCCESS);
+
+        assertChangedFile(relativeFilePath);
+        assertLineCount(relativeFilePath, 1);
+
+        Properties properties = getProperties(relativeFilePath);
+
+        assertEquals(properties.size(), 1);
+        assertEquals(properties.getProperty(testKey), testValue);
+
+    }
+
+    @Test
     public void successAddTest() throws IOException {
         AddProperty addProperty = new AddProperty().setPropertyName("zoo").setPropertyValue("zoov").relative("/src/main/resources/application.properties");
         assertEquals(addProperty.getPropertyName(), "zoo");


### PR DESCRIPTION
This bug fix allows Butterfly's AddProperty TU to add property to an empty file. This logic sends back an empty EOL character preventing AddProperty from looking for an EOL character of a line for an empty file.