### PR TITLE
#179 Skipping evaluation for package-info file

### DIFF
--- a/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/conditions/java/JavaMatch.java
+++ b/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/conditions/java/JavaMatch.java
@@ -20,6 +20,9 @@ import java.util.Set;
  * more than one type, only the outer one will be considered
  * during evaluation. If it has none, the evaluation will result
  * in false and a warning be returned.
+ * If the Java class file is named package-info.java, the file content
+ * will not be evaluated and false and a warning will be returned.
+ * The boolean result for package-info.java file is configurable though.
  *
  * @author facarvalho
  */
@@ -28,6 +31,8 @@ public class JavaMatch extends SingleCondition<JavaMatch> {
     private static final String DESCRIPTION = "Check if Java class in '%s' matches all specified criteria";
 
     private Set<JavaCondition> conditions = new HashSet<>();
+
+    private boolean packageInfo;
 
     /**
      * This utility parses and evaluates the specified Java class file
@@ -80,6 +85,28 @@ public class JavaMatch extends SingleCondition<JavaMatch> {
     }
 
     /**
+     * Returns the current boolean status of packageInfo.
+     *
+     * @return this packageInfo boolean status
+     */
+    public boolean getPackageInfo() {
+        return this.packageInfo;
+    }
+
+    /**
+     * Sets the result value for package info warning.
+     * By default the result for package-info.java
+     * file will be false.
+     *
+     * @param packageInfo boolean status of value for packageInfo warning
+     * @return this transformation utility condition instance
+     */
+    public JavaMatch setPackageInfo(boolean packageInfo) {
+        this.packageInfo = packageInfo;
+        return this;
+    }
+
+    /**
      * Add a new Java condition to be evaluated against the Java class.
      *
      * @param condition a Java condition to be used to evaluate the specified class
@@ -105,6 +132,10 @@ public class JavaMatch extends SingleCondition<JavaMatch> {
         try {
             fileInputStream = new FileInputStream(javaClassFile);
             CompilationUnit compilationUnit = JavaParser.parse(fileInputStream);
+
+            if (javaClassFile.getName().equals("package-info.java")) {
+                return TUExecutionResult.warning(this, new TransformationUtilityException("Skipping execution for " + javaClassFile.getAbsolutePath() + ". This is a package-info.java file."), this.packageInfo);
+            }
 
             // TODO
             // This should be done as part of validation, as soon as

--- a/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/conditions/java/JavaMatchTest.java
+++ b/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/conditions/java/JavaMatchTest.java
@@ -70,6 +70,54 @@ public class JavaMatchTest extends TransformationUtilityTestHelper {
     }
 
     @Test
+    public void packageInfoDefaultUnitTest() {
+        final String relativePath = "/src/main/java/com/testapp/package-info.java";
+
+        JavaMatch javaMatch = new JavaMatch().relative(relativePath);
+
+        Set<JavaCondition> conditions = new HashSet<>();
+        conditions.add(ext);
+        conditions.add(new AnnotatedWith(SuppressWarnings.class));
+
+        javaMatch.setConditions(conditions);
+
+        TUExecutionResult executionResult = javaMatch.execution(transformedAppFolder, transformationContext);
+
+        Assert.assertEquals(executionResult.getType(), TUExecutionResult.Type.WARNING);
+        Assert.assertFalse((Boolean) executionResult.getValue());
+        Assert.assertEquals(executionResult.getWarnings().size(), 1);
+        Assert.assertEquals(executionResult.getWarnings().get(0).getClass(), TransformationUtilityException.class);
+
+        File packageInfoFile = new File(transformedAppFolder, relativePath);
+        final String warningMessage = "Skipping execution for " + packageInfoFile.getAbsolutePath() + ". This is a package-info.java file.";
+        Assert.assertEquals(executionResult.getWarnings().get(0).getMessage(), warningMessage);
+    }
+
+    @Test
+    public void packageInfoSetterTest() {
+        final String relativePath = "/src/main/java/com/testapp/package-info.java";
+
+        JavaMatch javaMatch = new JavaMatch().relative(relativePath).setPackageInfo(true);
+
+        Set<JavaCondition> conditions = new HashSet<>();
+        conditions.add(ext);
+        conditions.add(new AnnotatedWith(SuppressWarnings.class));
+
+        javaMatch.setConditions(conditions);
+
+        TUExecutionResult executionResult = javaMatch.execution(transformedAppFolder, transformationContext);
+
+        Assert.assertEquals(executionResult.getType(), TUExecutionResult.Type.WARNING);
+        Assert.assertTrue((Boolean) executionResult.getValue());
+        Assert.assertEquals(executionResult.getWarnings().size(), 1);
+        Assert.assertEquals(executionResult.getWarnings().get(0).getClass(), TransformationUtilityException.class);
+
+        File packageInfoFile = new File(transformedAppFolder, relativePath);
+        final String warningMessage = "Skipping execution for " + packageInfoFile.getAbsolutePath() + ". This is a package-info.java file.";
+        Assert.assertEquals(executionResult.getWarnings().get(0).getMessage(), warningMessage);
+    }
+
+    @Test
     public void commentedOutShortClassTest() {
         JavaMatch javaMatch = new JavaMatch().relative("/src/main/java/com/testapp/CommentedOutShort.java");
 

--- a/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/file/FindFilesTest.java
+++ b/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/file/FindFilesTest.java
@@ -407,7 +407,7 @@ public class FindFilesTest extends TransformationUtilityTestHelper {
         Assert.assertNotNull(executionResult.getValue());
 
         List<File> files = (List<File>) executionResult.getValue();
-        Assert.assertEquals(files.size(), 53);
+        Assert.assertEquals(files.size(), 54);
 
         Assert.assertTrue(files.contains(new File(transformedAppFolder, "src")));
         Assert.assertTrue(files.contains(new File(transformedAppFolder, "blah")));

--- a/butterfly-utilities/src/test/resources/test-app/src/main/java/com/testapp/package-info.java
+++ b/butterfly-utilities/src/test/resources/test-app/src/main/java/com/testapp/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Various Java classes included for test purposes.
+ */
+package java.com.testapp;


### PR DESCRIPTION
These changes allow JavaMatch TU to skip evaluation for package-info file by default. It also allows users to set result to true.