### PR TITLE
#71 Updated description message for LocateFile TU

### DIFF
--- a/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/file/LocateFile.java
+++ b/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/file/LocateFile.java
@@ -23,6 +23,7 @@ import java.io.File;
  */
 public class LocateFile extends TransformationUtility<LocateFile> {
 
+    private static final String DESCRIPTION_RELATIVE_MISSING = "Locate specified file";
     private static final String DESCRIPTION_PARENT_ZERO = "Locate file %s";
     private static final String DESCRIPTION_PARENT = "Locate file %d levels above %s";
 
@@ -85,14 +86,8 @@ public class LocateFile extends TransformationUtility<LocateFile> {
     public String getDescription() {
         String location = getRelativePath();
         if (StringUtils.isBlank(location)) {
-            location = "root folder";
+            return DESCRIPTION_RELATIVE_MISSING;
         }
-
-        // FIXME
-        // An usage like the one below results in a wrong description.
-        // Instead of resulting in something like "Locate file '/foo/bar/init'" it results in "Locate file root folder"
-        //
-        // add(new LocateFile().absolute(APP_PACKAGE_LOCATION, "init");
 
         if (parentLevel == 0) {
             return String.format(DESCRIPTION_PARENT_ZERO, location);

--- a/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/file/LocateFileTest.java
+++ b/butterfly-utilities/src/test/java/com/paypal/butterfly/utilities/file/LocateFileTest.java
@@ -25,7 +25,7 @@ public class LocateFileTest extends TransformationUtilityTestHelper {
         File rootFile = (File) executionResult.getValue();
         Assert.assertEquals(rootFile.getAbsolutePath(), transformedAppFolder.getAbsolutePath());
         Assert.assertEquals(locateFile.getParentLevel(), 0);
-        Assert.assertEquals(locateFile.getDescription(), "Locate file root folder");
+        Assert.assertEquals(locateFile.getDescription(), "Locate specified file");
     }
 
     @Test


### PR DESCRIPTION
Description message for cases where the transformation context is not available or the relative file had not been set was automatically set `root folder`.
Changed the description to more generic message to handle cases for Locate file which can only be determined at runtime.