### PR TITLE
(incomplete) Adding support for properties as input parameter #167

### DIFF
--- a/butterfly-api/src/main/java/com/paypal/butterfly/api/ButterflyFacade.java
+++ b/butterfly-api/src/main/java/com/paypal/butterfly/api/ButterflyFacade.java
@@ -1,14 +1,14 @@
 package com.paypal.butterfly.api;
 
-import java.io.File;
-import java.util.List;
-import java.util.Properties;
-
 import com.paypal.butterfly.extensions.api.Extension;
 import com.paypal.butterfly.extensions.api.TransformationTemplate;
 import com.paypal.butterfly.extensions.api.exception.ButterflyException;
 import com.paypal.butterfly.extensions.api.exception.TemplateResolutionException;
 import com.paypal.butterfly.extensions.api.upgrade.UpgradePath;
+
+import java.io.File;
+import java.util.List;
+import java.util.Properties;
 
 /**
  * Butterfly façade
@@ -66,9 +66,10 @@ public interface ButterflyFacade {
      *                   for further details. The properties values are defined by the user requesting the transformation.
      *                   Properties are optional, so, if not desired, this parameter can be set to null.
      * @return a brand new {@link Configuration} object
+     * @throws IllegalArgumentException if properties object is invalid. Properties name must
+     *                   be non blank and only contain alphabetical characters, dots, underscore or hyphen. Properties
+     *                   object must be Strings and cannot be null.
      */
-
-    // TODO Validate properties names and throw IAEx if any is invalid (do the same to other 2 methods)
     Configuration newConfiguration(Properties properties);
 
     /**
@@ -92,6 +93,9 @@ public interface ButterflyFacade {
      *                   Properties are optional, so, if not desired, this parameter can be set to null.
      * @param zipOutput if true, the transformed application folder will be compressed into a zip file
      * @return a brand new {@link Configuration} object
+     * @throws IllegalArgumentException if properties object is invalid. Properties name must
+     *                   be non blank and only contain alphabetical characters, dots, underscore or hyphen. Properties
+     *                   object must be Strings and cannot be null.
      */
     Configuration newConfiguration(Properties properties, boolean zipOutput);
 
@@ -116,6 +120,9 @@ public interface ButterflyFacade {
      * @param zipOutput if true, the transformed application folder will be compressed into a zip file
      * @return a brand new {@link Configuration} object
      * @throws IllegalArgumentException if {@code outputFolder} is null, does not exist, or is not a directory
+     * @throws IllegalArgumentException if properties object is invalid. Properties name must
+     *                   be non blank and only contain alphabetical characters, dots, underscore or hyphen. Properties
+     *                   object must be Strings and cannot be null.
      */
     Configuration newConfiguration(Properties properties, File outputFolder, boolean zipOutput);
 

--- a/butterfly-api/src/main/java/com/paypal/butterfly/api/Configuration.java
+++ b/butterfly-api/src/main/java/com/paypal/butterfly/api/Configuration.java
@@ -13,7 +13,8 @@ import java.util.Properties;
 public interface Configuration {
 
     /**
-     * Return the folder where the transformed application is supposed to be placed
+     * Returns the folder where the transformed application is supposed to be placed,
+     * or null, if no custom folder has been specified
      *
      * @return the folder where the transformed application is supposed to be placed
      */
@@ -34,7 +35,7 @@ public interface Configuration {
     boolean isModifyOriginalFolder();
 
     /**
-     * Return a properties object specifying details about the transformation itself.
+     * Returns a properties object specifying details about the transformation itself.
      * These properties help to specialize the transformation, for example,
      * determining if certain operations should be skipped or not,
      * or how certain aspects of the transformation should be executed.

--- a/butterfly-core/src/main/java/com/paypal/butterfly/core/ConfigurationImpl.java
+++ b/butterfly-core/src/main/java/com/paypal/butterfly/core/ConfigurationImpl.java
@@ -1,7 +1,11 @@
 package com.paypal.butterfly.core;
 
 import java.io.File;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -20,6 +24,8 @@ class ConfigurationImpl implements Configuration {
     private boolean zipOutput = false;
     private boolean modifyOriginalFolder = true;
 
+    private static final Pattern propertyNameRegex = Pattern.compile("^[a-zA-Z\\._-]*$");
+
     /**
      * Creates and returns a new {@link Configuration} object
      * set to apply the transformation against the original application folder
@@ -37,9 +43,22 @@ class ConfigurationImpl implements Configuration {
      *                   for further details. The properties values are defined by the user requesting the transformation.
      *                   Properties are optional, so, if not desired, this parameter can be set to null.
      * @return a brand new {@link Configuration} object
+     * @throws IllegalArgumentException if properties object is invalid. Properties name must
+     *                   be non blank and only contain alphabetical characters, dots, underscore or hyphen. Properties
+     *                   object must be Strings and cannot be null.
      */
     ConfigurationImpl(Properties properties) {
         if (properties != null && properties.size() > 0) {
+
+            // Validating properties object
+            List<String> invalidProperties = properties.entrySet().stream()
+                    .filter(e -> !propertyNameRegex.matcher((String) e.getKey()).matches() || !(e.getValue() instanceof String))
+                    .map(e -> (String) e.getKey())
+                    .collect(Collectors.toList());
+            if (!invalidProperties.isEmpty()) {
+                throw new IllegalArgumentException("The following properties are invalid: " + invalidProperties);
+            }
+
             this.properties = properties;
         }
     }

--- a/butterfly-core/src/test/java/com/paypal/butterfly/core/ButterflyFacadeImplTest.java
+++ b/butterfly-core/src/test/java/com/paypal/butterfly/core/ButterflyFacadeImplTest.java
@@ -1,19 +1,6 @@
 package com.paypal.butterfly.core;
 
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
-
-import java.io.File;
-import java.util.List;
-
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
+import com.paypal.butterfly.api.Configuration;
 import com.paypal.butterfly.extensions.api.Extension;
 import com.paypal.butterfly.extensions.api.TransformationTemplate;
 import com.paypal.butterfly.extensions.api.exception.ButterflyException;
@@ -21,6 +8,20 @@ import com.paypal.butterfly.extensions.api.upgrade.UpgradePath;
 import com.paypal.butterfly.extensions.springboot.ButterflySpringBootExtension;
 import com.paypal.butterfly.extensions.springboot.JavaEEToSpringBoot;
 import com.paypal.butterfly.extensions.springboot.SpringBootUpgrade_1_5_6_to_1_5_7;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.powermock.modules.testng.PowerMockTestCase;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.List;
+import java.util.Properties;
+
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.testng.Assert.*;
 
 /**
  * ButterflyFacadeImplTest
@@ -46,9 +47,9 @@ public class ButterflyFacadeImplTest extends PowerMockTestCase {
     public void testGetRegisteredExtension() {
         when(extensionRegistry.getExtensions()).thenReturn(extensionRegistry_test.getExtensions());
         List<Extension> extensions = butterflyFacadeImpl.getExtensions();
-        Assert.assertNotNull(extensions);
-        Assert.assertEquals(extensions.size(), 1);
-        Assert.assertTrue(extensions.get(0) instanceof ButterflySpringBootExtension);
+        assertNotNull(extensions);
+        assertEquals(extensions.size(), 1);
+        assertTrue(extensions.get(0) instanceof ButterflySpringBootExtension);
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Template class name cannot be blank")
@@ -101,4 +102,59 @@ public class ButterflyFacadeImplTest extends PowerMockTestCase {
         butterflyFacadeImpl.transform(applicationFolder, upgradePath);
         verify(transformationEngine, times(1)).perform((UpgradePathTransformationRequest) anyObject());
     }
+
+    @Test
+    public void newConfigurationTest() {
+        assertNull(butterflyFacadeImpl.newConfiguration(null).getProperties());
+        assertNull(butterflyFacadeImpl.newConfiguration(new Properties()).getProperties());
+
+        try {
+            Properties properties = new Properties();
+            properties.put("", "v1");
+            properties.put(" ", "v2");
+            properties.put("a", new Object());
+            properties.put("b%", "v4");
+            butterflyFacadeImpl.newConfiguration(properties);
+            fail("IllegalArgumentException was supposed to be thrown due to invalid properties");
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "The following properties are invalid: [ , a, b%]");
+        }
+
+        Properties properties = new Properties();
+        properties.put("a", "1");
+        properties.put("b", "2");
+
+        Configuration c1 = butterflyFacadeImpl.newConfiguration(properties);
+        assertEquals(c1.getProperties(), properties);
+        assertNull(c1.getOutputFolder());
+        assertTrue(c1.isModifyOriginalFolder());
+        assertFalse(c1.isZipOutput());
+
+        Configuration c2 = butterflyFacadeImpl.newConfiguration(null, false);
+        assertNull(c2.getProperties());
+        assertNull(c2.getOutputFolder());
+        assertFalse(c2.isModifyOriginalFolder());
+        assertFalse(c2.isZipOutput());
+
+        Configuration c3 = butterflyFacadeImpl.newConfiguration(null, true);
+        assertNull(c3.getProperties());
+        assertNull(c3.getOutputFolder());
+        assertFalse(c3.isModifyOriginalFolder());
+        assertTrue(c3.isZipOutput());
+
+        File file = new File(".");
+
+        Configuration c4 = butterflyFacadeImpl.newConfiguration(null, file, false);
+        assertNull(c4.getProperties());
+        assertEquals(c4.getOutputFolder(), file);
+        assertFalse(c4.isModifyOriginalFolder());
+        assertFalse(c4.isZipOutput());
+
+        Configuration c5 = butterflyFacadeImpl.newConfiguration(null, file, true);
+        assertNull(c5.getProperties());
+        assertEquals(c5.getOutputFolder(), file);
+        assertFalse(c5.isModifyOriginalFolder());
+        assertTrue(c5.isZipOutput());
+    }
+
 }

--- a/butterfly-extensions-api/src/main/java/com/paypal/butterfly/extensions/api/TransformationUtility.java
+++ b/butterfly-extensions-api/src/main/java/com/paypal/butterfly/extensions/api/TransformationUtility.java
@@ -637,7 +637,9 @@ public abstract class TransformationUtility<T extends TransformationUtility> imp
         // Checking for UNLESS condition
         if(unlessConditionAttributeName != null) {
             Object conditionResult = transformationContext.get(unlessConditionAttributeName);
-            if (conditionResult != null && conditionResult instanceof Boolean && ((Boolean) conditionResult).booleanValue()) {
+            if (conditionResult != null &&
+                    ((conditionResult instanceof Boolean && ((Boolean) conditionResult).booleanValue()) || (conditionResult instanceof String && conditionResult.equals("true")))) {
+
                 String details = String.format("%s was skipped due to failing 'unless' condition: %s", getName(), unlessConditionAttributeName);
                 hasBeenPerformed.set(true);
                 return PerformResult.skippedCondition(this, details);


### PR DESCRIPTION
This commit adds related tests for Configuration object, Facade, CLI, Transformation Context, Transformation Engine and Transformation Utility.