### PR TITLE
[350] Display 'LATEST' if the -u argument isn't supplied..

### DIFF
--- a/butterfly-cli/src/main/java/com/paypal/butterfly/cli/ButterflyCliRunner.java
+++ b/butterfly-cli/src/main/java/com/paypal/butterfly/cli/ButterflyCliRunner.java
@@ -198,7 +198,8 @@ class ButterflyCliRunner extends ButterflyCliOption {
                 String upgradeVersion = (String) optionSet.valueOf(CLI_OPTION_UPGRADE_VERSION);
                 String originalVersion = firstStepClass.newInstance().getCurrentVersion();
 
-                logger.info("Performing upgrade from version {} to version {} (it might take a few seconds)", originalVersion, upgradeVersion);
+                logger.info("Performing upgrade from version {} to version {} (it might take a few seconds)",
+                        originalVersion, Optional.ofNullable(upgradeVersion).orElse("LATEST"));
                 transformationResult = butterflyFacade.transform(applicationFolder, firstStepClass, upgradeVersion, configuration).get();
             } else {
                 logger.info("Performing transformation (it might take a few seconds)");


### PR DESCRIPTION
Fix for #350.

This jives with CLI help output.  I almost defaulted the argument value
to LATEST.  That is _probably_ the better way to go, but the code
already works against `null`, and I didn't want to take the time:(

Just too much to do!