### PR TITLE
Butterfly CLI allows escaped semicolons and equals as extension property value when passed using -p

### DIFF
--- a/butterfly-cli/src/main/java/com/paypal/butterfly/cli/ButterflyCliRunner.java
+++ b/butterfly-cli/src/main/java/com/paypal/butterfly/cli/ButterflyCliRunner.java
@@ -155,7 +155,8 @@ class ButterflyCliRunner extends ButterflyCliOption {
         try {
             if (optionSet.has(CLI_OPTION_INLINE_PROPERTIES)) {
                 String inlineProperties = (String) optionSet.valueOf(CLI_OPTION_INLINE_PROPERTIES);
-                try (StringReader stringReader = new StringReader(inlineProperties.replace(';', '\n'))) {
+                // Regex to ignore escaped semi-colons 
+                try (StringReader stringReader = new StringReader(inlineProperties.replaceAll("(?<!\\\\);", "\n"))) {
                     properties.load(stringReader);
                 }
             } else if (optionSet.has(CLI_OPTION_PROPERTIES_FILE)) {

--- a/butterfly-cli/src/test/java/com/paypal/butterfly/cli/ButterflyCliRunnerTest.java
+++ b/butterfly-cli/src/test/java/com/paypal/butterfly/cli/ButterflyCliRunnerTest.java
@@ -1,0 +1,58 @@
+package com.paypal.butterfly.cli;
+
+import org.testng.annotations.Test;
+
+import com.paypal.butterfly.api.TransformationRequest;
+import com.paypal.butterfly.api.TransformationResult;
+import com.paypal.butterfly.api.Configuration;
+
+import java.util.Properties;
+import java.io.File;
+import java.net.URISyntaxException;
+
+import static org.testng.Assert.*;
+
+/**
+ * Test for ButterflyCliRunner
+*/
+public class ButterflyCliRunnerTest {
+   
+    // Test for parsing argument value for CLI option -p
+    @Test
+    public void testInlineProperties() throws URISyntaxException{
+        String sampleAppPath = new File(this.getClass().getResource("/sample_app").toURI()).getAbsolutePath();
+        ButterflyCliRun run = new ButterflyCliApp().run(sampleAppPath,"-p", "firstkey=firstvalue;secondkey=secondvalue");
+        Properties properties = run.getTransformationResult().getTransformationRequest().getConfiguration().getProperties(); 
+        assertEquals(run.getExitStatus(), 0);
+        assertEquals(run.getInputArguments(), new String[]{sampleAppPath, "-p","firstkey=firstvalue;secondkey=secondvalue"});
+        assertEquals(properties.get("firstkey"),"firstvalue");
+        assertEquals(properties.get("secondkey"),"secondvalue");
+
+    }
+
+    // Test for parsing argument value for CLI option -p
+    @Test
+    public void testInlinePropertiesWithEscapedSemicolon() throws URISyntaxException{
+        // Test with escaped ';' in the value
+        String sampleAppPath = new File(this.getClass().getResource("/sample_app").toURI()).getAbsolutePath();
+        ButterflyCliRun run = new ButterflyCliApp().run(sampleAppPath,"-p", "firstkey=first\\;value;secondkey=second\\;value");
+        Properties properties = run.getTransformationResult().getTransformationRequest().getConfiguration().getProperties(); 
+        assertEquals(run.getExitStatus(), 0);
+        assertEquals(run.getInputArguments(), new String[]{sampleAppPath, "-p","firstkey=first\\;value;secondkey=second\\;value"});
+        assertEquals(properties.get("firstkey"),"first;value");
+        assertEquals(properties.get("secondkey"),"second;value");
+    }
+
+    // Test for parsing argument value for CLI option -p
+    @Test
+    public void testInlinePropertiesWithEscapedEqualSign() throws URISyntaxException{
+        // Test with escaped '=' in the value
+        String sampleAppPath = new File(this.getClass().getResource("/sample_app").toURI()).getAbsolutePath();
+        ButterflyCliRun run = new ButterflyCliApp().run(sampleAppPath,"-p", "firstkey=first\\=value;secondkey=second\\=value");
+        Properties properties = run.getTransformationResult().getTransformationRequest().getConfiguration().getProperties(); 
+        assertEquals(run.getExitStatus(), 0);
+        assertEquals(run.getInputArguments(), new String[]{sampleAppPath, "-p","firstkey=first\\=value;secondkey=second\\=value"});
+        assertEquals(properties.get("firstkey"),"first=value");
+        assertEquals(properties.get("secondkey"),"second=value");
+    }
+}


### PR DESCRIPTION
Fixes issue #360 

I have added three test cases. 
Please let me know if I need to change anything. 