### PR TITLE
Improve IllegalArgumentException if "version to" is older than current version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,11 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
+        maven{
+            // For versioncompare library
+            // (https://mvnrepository.com/artifact/com.g00fy2/versioncompare/1.3.2)
+            url "https://repo.spring.io/plugins-release/"
+        }
     }
 
     buildScan {
@@ -260,6 +265,7 @@ ext.lib = [
         slf4j_api: "org.slf4j:slf4j-api:1.7.21",
         logback: "ch.qos.logback:logback-classic:1.1.7",
         zip4j: "net.lingala.zip4j:zip4j:1.3.2",
+        version_compare :"com.g00fy2:versioncompare:1.3.7",
 
         // Swagger
         swagger_annotations: "io.swagger.core.v3:swagger-annotations:2.0.8",

--- a/butterfly-core/build.gradle
+++ b/butterfly-core/build.gradle
@@ -13,7 +13,8 @@ dependencies {
             lib.zip4j,
             lib.annotations,
             lib.commons_lang3,
-            lib.plexus_utils
+            lib.plexus_utils,
+            lib.version_compare
     testCompile project(':extensions-catalog:butterfly-springboot-extension')
     testCompile(lib.testng) {
         exclude(module: 'aopalliance')

--- a/butterfly-core/src/main/java/com/paypal/butterfly/core/UpgradePath.java
+++ b/butterfly-core/src/main/java/com/paypal/butterfly/core/UpgradePath.java
@@ -5,6 +5,7 @@ import com.paypal.butterfly.extensions.api.exception.ButterflyRuntimeException;
 import com.paypal.butterfly.extensions.api.upgrade.UpgradeStep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.g00fy2.versioncompare.Version;
 
 /**
  * Upgrade paths enable upgrading an application from one version to a target version,
@@ -59,8 +60,13 @@ final class UpgradePath {
         }
         if (upgradeVersion == null || upgradeVersion.isEmpty()) {
             upgradeVersion = getLastVersion();
+        } else if(firstStep.getCurrentVersion().equals(upgradeVersion)){
+            throw new IllegalArgumentException("The requested upgrade version (" + upgradeVersion + ") is the same as the version the application is currently at");
+            //throw new IllegalArgumentException("The requested upgrade version is the same as the version the application is currently at");
+        } else if(isOlderTargetVersion(upgradeVersion)){
+            throw new IllegalArgumentException("The requested upgrade version (" + upgradeVersion + ") is older than the version the application is currently at (" + firstStep.getCurrentVersion() + ")");
         } else if(!upgradeVersionValidation(upgradeVersion)) {
-            throw new IllegalArgumentException("Upgrade version " + upgradeVersion + " is invalid");
+            throw new IllegalArgumentException("The requested upgrade version (" + upgradeVersion + ") is inexistent");
         }
         this.nextStep = firstStep;
         this.upgradeVersion = upgradeVersion;
@@ -94,6 +100,14 @@ final class UpgradePath {
         } while (us != null);
 
         return false;
+    }
+
+    /*
+     * Returns true if {@code targetVersion} is older than {@code currentVersion}
+     * of {@code firstStep}
+    */
+    private boolean isOlderTargetVersion(String targetVersion){
+        return new Version(targetVersion).isLowerThan(firstStep.getCurrentVersion());
     }
 
     /**

--- a/butterfly-core/src/main/java/com/paypal/butterfly/core/UpgradePath.java
+++ b/butterfly-core/src/main/java/com/paypal/butterfly/core/UpgradePath.java
@@ -60,12 +60,11 @@ final class UpgradePath {
         }
         if (upgradeVersion == null || upgradeVersion.isEmpty()) {
             upgradeVersion = getLastVersion();
-        } else if(firstStep.getCurrentVersion().equals(upgradeVersion)){
+        } else if (firstStep.getCurrentVersion().equals(upgradeVersion)) {
             throw new IllegalArgumentException("The requested upgrade version (" + upgradeVersion + ") is the same as the version the application is currently at");
-            //throw new IllegalArgumentException("The requested upgrade version is the same as the version the application is currently at");
-        } else if(isOlderTargetVersion(upgradeVersion)){
+        } else if (isOlderTargetVersion(upgradeVersion)) {
             throw new IllegalArgumentException("The requested upgrade version (" + upgradeVersion + ") is older than the version the application is currently at (" + firstStep.getCurrentVersion() + ")");
-        } else if(!upgradeVersionValidation(upgradeVersion)) {
+        } else if (!upgradeVersionValidation(upgradeVersion)) {
             throw new IllegalArgumentException("The requested upgrade version (" + upgradeVersion + ") is inexistent");
         }
         this.nextStep = firstStep;

--- a/butterfly-core/src/test/java/com/paypal/butterfly/core/UpgradePathTest.java
+++ b/butterfly-core/src/test/java/com/paypal/butterfly/core/UpgradePathTest.java
@@ -1,0 +1,35 @@
+package com.paypal.butterfly.core;
+
+import org.testng.annotations.Test;
+import com.paypal.butterfly.extensions.springboot.SpringBootUpgrade_1_5_6_to_1_5_7;
+
+import static org.testng.Assert.*;
+
+/**
+ * UpgradePath Test
+ *
+ * Created by Badal Sarkar on 10/29/2020
+ */
+public class UpgradePathTest {
+
+    @Test
+    public void testUpgradePathIsValid(){
+        UpgradePath upgradePath = new UpgradePath(SpringBootUpgrade_1_5_6_to_1_5_7.class, "1.5.7");
+        assertTrue(upgradePath instanceof UpgradePath);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp= "The requested upgrade version \\(1.5.9\\) is inexistent")
+    public void testUpgradePathNonExsists(){
+        new UpgradePath(SpringBootUpgrade_1_5_6_to_1_5_7.class, "1.5.9");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp= "The requested upgrade version \\(1.5.6\\) is the same as the version the application is currently at")
+    public void testUpgradePathEqualsCurrentPath(){
+        new UpgradePath(SpringBootUpgrade_1_5_6_to_1_5_7.class, "1.5.6");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp= "The requested upgrade version \\(1.5.5\\) is older than the version the application is currently at \\(1.5.6\\)")
+    public void testUpgradePathOlderThanCurrentVersion(){
+        new UpgradePath(SpringBootUpgrade_1_5_6_to_1_5_7.class, "1.5.5");
+    }
+}


### PR DESCRIPTION
Fixed #214 .

I have used [`Gradle-Core`](https://mvnrepository.com/artifact/org.gradle/gradle-core/6.1.1) library's [`VersionNumber`](https://github.com/gradle/gradle/blob/master/subprojects/core/src/main/java/org/gradle/util/VersionNumber.java) class to compare the `currentVersion` and `upgradeVersion`. 

I have also added three test cases. 

Please let me know if anything needs to be changes. 

Thank you. 