### PR TITLE
Add support for loading extensions packaged as spring-boot uber jars.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ branches:
   - master
 
 install:
-  - ./gradlew build jacocoRootReport jacocoTestCoverageVerification --scan
+  - ./gradlew build jacocoRootReport jacocoTestCoverageVerification --scan --info
 
 after_script:
   # Installing Codacy code coverage reporter upload tool and uploading Cobertura report to Codacy

--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,8 @@ allprojects {
         mavenLocal()
         mavenCentral()
         maven{
-            // For versioncompare library
-            // (https://mvnrepository.com/artifact/com.g00fy2/versioncompare/1.3.2)
             url "https://repo.spring.io/plugins-release/"
+            url "https://dl.bintray.com/g00fy2/maven"
         }
     }
 
@@ -235,6 +234,7 @@ ext.lib = [
         spring_context: "org.springframework:spring-context:4.3.2.RELEASE",
         spring_boot_starter: "org.springframework.boot:spring-boot-starter:1.4.0.RELEASE",
         spring_boot_autoconfigure: "org.springframework.boot:spring-boot-autoconfigure:1.4.0.RELEASE",
+        spring_boot_loader: "org.springframework.boot:spring-boot-loader:1.4.0.RELEASE",
         spring_test: "org.springframework:spring-test:4.3.2.RELEASE",
 
         // Maven
@@ -255,6 +255,7 @@ ext.lib = [
 
         // Utilities
         annotations: "com.google.code.findbugs:annotations:3.0.0",
+        classgraph: "io.github.classgraph:classgraph:4.8.90",
         commons_io: "commons-io:commons-io:2.5",
         commons_lang3: "org.apache.commons:commons-lang3:3.7",
         commons_collections4: "org.apache.commons:commons-collections4:4.0",

--- a/butterfly-cli-package/src/main/resources/butterfly/butterfly
+++ b/butterfly-cli-package/src/main/resources/butterfly/butterfly
@@ -4,4 +4,7 @@ if [[ -z "$BUTTERFLY_HOME" ]]; then
     BUTTERFLY_HOME=$(dirname "$SCRIPT_PATH")
     export BUTTERFLY_HOME
 fi
-java -cp $BUTTERFLY_HOME"/lib/*":$BUTTERFLY_HOME"/extensions/*" com.paypal.butterfly.cli.ButterflyCliApp $*
+
+java -cp $BUTTERFLY_HOME"/lib/*":$BUTTERFLY_HOME"/extensions/*" \
+    -Dloader.main=com.paypal.butterfly.cli.ButterflyCliApp \
+    org.springframework.boot.loader.PropertiesLauncher $*

--- a/butterfly-cli-package/src/main/resources/butterfly/butterfly.cmd
+++ b/butterfly-cli-package/src/main/resources/butterfly/butterfly.cmd
@@ -6,4 +6,7 @@ if defined BUTTERFLY_HOME (
   set __BUTTERFLY_HOME__=%BUTTERFLY_HOME%
 )
 
-java -cp "%__BUTTERFLY_HOME__%\lib\*";"%__BUTTERFLY_HOME__%\extensions\*" com.paypal.butterfly.cli.ButterflyCliApp %*
+
+java -cp "%__BUTTERFLY_HOME__%\lib\*";"%__BUTTERFLY_HOME__%\extensions\*" ^
+    -Dloader.main=com.paypal.butterfly.cli.ButterflyCliApp ^
+    com.paypal.butterfly.cli.ButterflyCliApp %*

--- a/butterfly-core/build.gradle
+++ b/butterfly-core/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     compile lib.annotation_api,
             lib.slf4j_api,
             lib.gson,
+            lib.spring_boot_loader,
+            lib.classgraph,
             lib.reflections,
             lib.commons_io,
             lib.zip4j,

--- a/butterfly-core/src/main/java/com/paypal/butterfly/core/ExtensionRegistry.java
+++ b/butterfly-core/src/main/java/com/paypal/butterfly/core/ExtensionRegistry.java
@@ -73,7 +73,7 @@ class ExtensionRegistry {
 
         for (Class<? extends Extension<?>> extensionClass : extensionClasses) {
             try {
-                final Extension<?> extension = extensionClass.getConstructor().newInstance();
+                Extension<?> extension = extensionClass.getConstructor().newInstance();
                 newExtensions.add(extension);
             } catch (Exception e) {
                 logger.error("Cannot register extension class {}", extensionClass, e);

--- a/butterfly-core/src/test/java/com/paypal/butterfly/core/ExtensionRegistryTest.java
+++ b/butterfly-core/src/test/java/com/paypal/butterfly/core/ExtensionRegistryTest.java
@@ -1,11 +1,19 @@
 package com.paypal.butterfly.core;
 
-import com.paypal.butterfly.extensions.api.Extension;
 import com.paypal.butterfly.extensions.springboot.ButterflySpringBootExtension;
-import org.testng.Assert;
+import org.springframework.core.io.ClassPathResource;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.testng.Assert.assertEquals;
 
 /**
  * ExtensionRegistry Test
@@ -16,11 +24,40 @@ public class ExtensionRegistryTest {
 
     @Test
     public void testValidExtensionRegistry() {
-        ExtensionRegistry extensionRegistry  = new ExtensionRegistry();
-        List<Extension> extensions = extensionRegistry.getExtensions();
-        Assert.assertNotNull(extensions);
-        Assert.assertEquals(extensions.size(), 1);
-        Assert.assertTrue(extensions.get(0) instanceof ButterflySpringBootExtension);
+        ExtensionRegistry extensionRegistry = new ExtensionRegistry();
+        List<String> extensionNames = getExtensions(extensionRegistry);
+        assertEquals(extensionNames.size(), 1);
+        assertThat(extensionNames.get(0), is(ButterflySpringBootExtension.class.getName()));
     }
 
+    @Test
+    public void testSpringBoot() throws IOException {
+        final ClassLoader original = Thread.currentThread().getContextClassLoader();
+
+        final URL url = new ClassPathResource("test-spring-boot-uber-lib/spring-boot-uber-lib.jar").getURL();
+        final ClassLoader loader = SpringBootClassLoaderFactory.create(url);
+        Thread.currentThread().setContextClassLoader(loader);
+
+        try {
+            ExtensionRegistry extensionRegistry = new ExtensionRegistry();
+            List<String> extensionNames = getExtensions(extensionRegistry);
+
+            List<String> expectedExtensionNames = Arrays.asList(ButterflySpringBootExtension.class.getName(),
+                    "com.paypal.butterfly.test.springboot.UpgradeAppExtension",
+                    "com.paypal.butterfly.test.springboot.UpgradeLibraryExtension");
+            assertThat(extensionNames, is(expectedExtensionNames));
+
+        } finally {
+            Thread.currentThread().setContextClassLoader(original);
+        }
+    }
+
+    private List<String> getExtensions(ExtensionRegistry extensionRegistry) {
+        return extensionRegistry.getExtensions()
+                .stream()
+                .filter(extension -> isNotEmpty(extension.getDescription()))
+                .filter(extension -> isNotEmpty(extension.getVersion()))
+                .map(obj -> obj.getClass().getName())
+                .collect(toList());
+    }
 }

--- a/butterfly-core/src/test/java/com/paypal/butterfly/core/ExtensionRegistryTest.java
+++ b/butterfly-core/src/test/java/com/paypal/butterfly/core/ExtensionRegistryTest.java
@@ -1,6 +1,7 @@
 package com.paypal.butterfly.core;
 
 import com.paypal.butterfly.extensions.springboot.ButterflySpringBootExtension;
+import org.springframework.core.io.ClassPathResource;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -56,10 +57,15 @@ public class ExtensionRegistryTest {
     }
 
     private URL findJar(String jarName) throws IOException {
-        try (Stream<Path> stream = Files.walk(Paths.get(".."))) {
+        URL url = new ClassPathResource("test-spring-boot-uber-lib/spring-boot-uber-lib.jar").getURL();
+        System.out.println("jar Url: " + url);
+
+        Path root = Paths.get("..").toAbsolutePath().normalize();
+        System.out.println("search root: " + root);
+        try (Stream<Path> stream = Files.walk(root)) {
             Path jarPath = stream.filter(path -> path.endsWith(jarName))
                     .findFirst()
-                    .orElseThrow(IllegalArgumentException::new);
+                    .orElseThrow(() -> new IllegalArgumentException("Cannot find " + jarName + " in " + root));
             return jarPath.toUri().toURL();
         }
     }

--- a/butterfly-core/src/test/java/com/paypal/butterfly/core/ExtensionRegistryTest.java
+++ b/butterfly-core/src/test/java/com/paypal/butterfly/core/ExtensionRegistryTest.java
@@ -1,7 +1,6 @@
 package com.paypal.butterfly.core;
 
 import com.paypal.butterfly.extensions.springboot.ButterflySpringBootExtension;
-import org.springframework.core.io.ClassPathResource;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -57,9 +56,6 @@ public class ExtensionRegistryTest {
     }
 
     private URL findJar(String jarName) throws IOException {
-        URL url = new ClassPathResource("test-spring-boot-uber-lib/spring-boot-uber-lib.jar").getURL();
-        System.out.println("jar Url: " + url);
-
         Path root = Paths.get("..").toAbsolutePath().normalize();
         System.out.println("search root: " + root);
         try (Stream<Path> stream = Files.walk(root)) {

--- a/butterfly-core/src/test/java/com/paypal/butterfly/core/SpringBootClassLoaderFactory.java
+++ b/butterfly-core/src/test/java/com/paypal/butterfly/core/SpringBootClassLoaderFactory.java
@@ -1,0 +1,78 @@
+package com.paypal.butterfly.core;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.loader.JarLauncher;
+import org.springframework.boot.loader.archive.Archive;
+import org.springframework.boot.loader.archive.JarFileArchive;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+/**
+ * Factory creating ClassLoaders that can read spring-boot uber jars
+ */
+public class SpringBootClassLoaderFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(SpringBootClassLoaderFactory.class);
+
+    public static ClassLoader create(URL url) {
+        try {
+            Archive archive = newArchive(url);
+            NoOpJarLauncher noOpJarLauncher = new NoOpJarLauncher(archive);
+            noOpJarLauncher.launch(new String[0]);
+            return noOpJarLauncher.classLoader;
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot create ClassLoader for spring-boot uber jar. url=" + url, e);
+        }
+    }
+
+    public static boolean isSpringBootUberJar(URL url) {
+        try {
+            Archive archive = newArchive(url);
+            Manifest manifest = archive.getManifest();
+            if (manifest == null) {
+                return false;
+            }
+
+            Attributes mainAttributes = manifest.getMainAttributes();
+            return mainAttributes.containsKey(new Attributes.Name("Spring-Boot-Lib"));
+        } catch (IOException e) {
+            logger.warn("Cannot detect spring-boot uber jar. url={}", url);
+            return false;
+        }
+    }
+
+    private static Archive newArchive(URL url) throws IOException {
+        String file = url.getFile();
+        return new JarFileArchive(new File(file));
+    }
+
+    private static class NoOpJarLauncher extends JarLauncher {
+
+        private ClassLoader classLoader;
+
+        public NoOpJarLauncher(Archive archive) {
+            super(archive);
+        }
+
+        @Override
+        public void launch(String[] args) throws Exception {
+            super.launch(args);
+        }
+
+        @Override
+        public void launch(String[] args, String launchClass, ClassLoader classLoader) throws Exception {
+            this.classLoader = classLoader;
+        }
+
+        @Override
+        protected String getMainClass() throws Exception {
+            return "";
+        }
+    }
+}
+


### PR DESCRIPTION
To make it easier for an extension to include its own transitive dependencies,
change butterfly so that it can load extension jars that contain nested jars
created by spring-boot maven plugin.

Fixes #364