### PR TITLE
Upgrade Guava to v30.0 Issue #368

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -259,7 +259,7 @@ ext.lib = [
         commons_io: "commons-io:commons-io:2.5",
         commons_lang3: "org.apache.commons:commons-lang3:3.7",
         commons_collections4: "org.apache.commons:commons-collections4:4.0",
-        guava: "com.google.guava:guava:15.0",
+        guava: "com.google.guava:guava:30.0-jre",
         jopt_simple: "net.sf.jopt-simple:jopt-simple:5.0.2",
         plexus_utils: "org.codehaus.plexus:plexus-utils:3.1.0",
         reflections: "org.reflections:reflections:0.9.10",


### PR DESCRIPTION
Fixes #368 .

The Guava library has been upgraded to latest version v30.0-jre.