### PR TITLE
Allow numbers in extension property

### DIFF
--- a/butterfly-core/src/main/java/com/paypal/butterfly/core/ConfigurationImpl.java
+++ b/butterfly-core/src/main/java/com/paypal/butterfly/core/ConfigurationImpl.java
@@ -24,7 +24,7 @@ class ConfigurationImpl implements Configuration {
     private boolean zipOutput = false;
     private boolean modifyOriginalFolder = true;
 
-    private static final Pattern propertyNameRegex = Pattern.compile("^[a-zA-Z\\._-]*$");
+    private static final Pattern propertyNameRegex = Pattern.compile("^[a-zA-Z][a-zA-Z0-9\\._-]*$");  
 
     /**
      * Creates and returns a new {@link Configuration} object
@@ -44,8 +44,9 @@ class ConfigurationImpl implements Configuration {
      *                   Properties are optional, so, if not desired, this parameter can be set to null.
      * @return a brand new {@link Configuration} object
      * @throws IllegalArgumentException if properties object is invalid. Properties name must
-     *                   be non blank and only contain alphabetical characters, dots, underscore or hyphen. Properties
-     *                   object must be Strings and cannot be null.
+     *                   be non blank and the first character must be an alphabet and the others may
+     *                   be alphabetic, numeric, dot, underscore, or hyphen.  Properties value
+     *                   must be Strings and cannot be null.
      */
     ConfigurationImpl(Properties properties) {
         if (properties != null && properties.size() > 0) {

--- a/butterfly-core/src/test/java/com/paypal/butterfly/core/ButterflyFacadeImplTest.java
+++ b/butterfly-core/src/test/java/com/paypal/butterfly/core/ButterflyFacadeImplTest.java
@@ -92,17 +92,23 @@ public class ButterflyFacadeImplTest extends PowerMockTestCase {
             Properties properties = new Properties();
             properties.put("", "v1");
             properties.put(" ", "v2");
+            properties.put("1a", "v3");
+            properties.put("-a", "v4");
+            properties.put("#a", "v5");
             properties.put("a", new Object());
-            properties.put("b%", "v4");
+            properties.put("b%", "v6");
+            System.err.println(properties);
             butterflyFacadeImpl.newConfiguration(properties);
             fail("IllegalArgumentException was supposed to be thrown due to invalid properties");
         } catch (IllegalArgumentException e) {
-            assertEquals(e.getMessage(), "The following properties are invalid: [ , a, b%]");
+            assertEquals(e.getMessage(), "The following properties are invalid: [1a,  , a, -a, b%, #a, ]");
         }
 
         Properties properties = new Properties();
         properties.put("a", "1");
         properties.put("b", "2");
+        properties.put("a2", "3");
+        properties.put("a2-", "4");
 
         Configuration c1 = butterflyFacadeImpl.newConfiguration(properties);
         assertEquals(c1.getProperties(), properties);


### PR DESCRIPTION
Fixes #359 .
The extension property name used with "-p" option, now allows numbers. I have also updated the test. 
Thank you. 