### PR TITLE
Issue #372 Updated ButterflyFacadeImplTest

### DIFF
--- a/butterfly-core/src/main/java/com/paypal/butterfly/core/ConfigurationImpl.java
+++ b/butterfly-core/src/main/java/com/paypal/butterfly/core/ConfigurationImpl.java
@@ -55,6 +55,7 @@ class ConfigurationImpl implements Configuration {
             List<String> invalidProperties = properties.entrySet().stream()
                     .filter(e -> !propertyNameRegex.matcher((String) e.getKey()).matches() || !(e.getValue() instanceof String))
                     .map(e -> (String) e.getKey())
+                    .sorted()
                     .collect(Collectors.toList());
             if (!invalidProperties.isEmpty()) {
                 throw new IllegalArgumentException("The following properties are invalid: " + invalidProperties);

--- a/butterfly-core/src/test/java/com/paypal/butterfly/core/ButterflyFacadeImplTest.java
+++ b/butterfly-core/src/test/java/com/paypal/butterfly/core/ButterflyFacadeImplTest.java
@@ -14,6 +14,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.times;
@@ -87,7 +88,7 @@ public class ButterflyFacadeImplTest extends PowerMockTestCase {
     public void newConfigurationTest() {
         assertNull(butterflyFacadeImpl.newConfiguration(null).getProperties());
         assertNull(butterflyFacadeImpl.newConfiguration(new Properties()).getProperties());
-
+        List<String> invalidProperties=null;
         try {
             Properties properties = new Properties();
             properties.put("", "v1");
@@ -97,11 +98,14 @@ public class ButterflyFacadeImplTest extends PowerMockTestCase {
             properties.put("#a", "v5");
             properties.put("a", new Object());
             properties.put("b%", "v6");
-            System.err.println(properties);
+            invalidProperties = properties.entrySet().stream()
+                    .map(e -> (String) e.getKey())
+                    .sorted()
+                    .collect(Collectors.toList());
             butterflyFacadeImpl.newConfiguration(properties);
             fail("IllegalArgumentException was supposed to be thrown due to invalid properties");
         } catch (IllegalArgumentException e) {
-            assertEquals(e.getMessage(), "The following properties are invalid: [1a,  , a, -a, b%, #a, ]");
+            assertEquals(e.getMessage(), "The following properties are invalid: "+invalidProperties);
         }
 
         Properties properties = new Properties();


### PR DESCRIPTION
Fixes #372 
The test case asserts that the error message contains the keys
of a Properties object. As Properties is a hash table, the order of
keys in the error message differs and the assertion fails.

Now, the keys are sorted in the original function call so that the
order or keys in the error message is the same as assertion.