### PR TITLE
Fix FindFiles to not return canonical file path.

### DIFF
--- a/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/file/FindFiles.java
+++ b/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/file/FindFiles.java
@@ -1,6 +1,8 @@
 package com.paypal.butterfly.utilities.file;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -343,7 +345,7 @@ public class FindFiles extends TransformationUtility<FindFiles> {
             Collection<File> allFolders = FileUtils.listFilesAndDirs(searchRootFolder, new NotFileFilter(TrueFileFilter.INSTANCE), (recursive ? TrueFileFilter.INSTANCE : DirectoryFileFilter.DIRECTORY));
             allFolders.remove(searchRootFolder);
             for (File folder : allFolders) {
-                if (!recursive && !folder.getParentFile().equals(searchRootFolder)) {
+                if (!recursive && !fileEquals(folder.getParentFile(), searchRootFolder)) {
                     continue;
                 }
                 if (filter.accept(folder)) {
@@ -370,4 +372,16 @@ public class FindFiles extends TransformationUtility<FindFiles> {
         return result;
     }
 
+    private boolean fileEquals(File left, File right) {
+        if (left.equals(right)) {
+            return true;
+        }
+        try {
+            File canonicalLeft = left.getCanonicalFile();
+            File canonicalRight = right.getCanonicalFile();
+            return canonicalLeft.equals(canonicalRight);
+        } catch (IOException e) {
+            return false;
+        }
+    }
 }

--- a/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/file/FindFiles.java
+++ b/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/file/FindFiles.java
@@ -1,8 +1,6 @@
 package com.paypal.butterfly.utilities.file;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;

--- a/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/file/FindFiles.java
+++ b/butterfly-utilities/src/main/java/com/paypal/butterfly/utilities/file/FindFiles.java
@@ -310,12 +310,7 @@ public class FindFiles extends TransformationUtility<FindFiles> {
 
     @Override
     protected TUExecutionResult execution(File transformedAppFolder, TransformationContext transformationContext) {
-        final File searchRootFolder;
-        try {
-            searchRootFolder = getAbsoluteFile(transformedAppFolder, transformationContext).getCanonicalFile();
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        final File searchRootFolder = getAbsoluteFile(transformedAppFolder, transformationContext);
 
         String _pathRegex = pathRegex;
         if (pathRegex != null && File.separatorChar != '/') {


### PR DESCRIPTION
```
Fix FindFiles to not return cannonical file path.

Partially revert 887e3e2fbb7ebc8de65f991f92220b696f83ae7a.

Change FindFiles to not return cannonical file path, undoing behavior change
introduced in 3.1.0 version and restoring back to 3.0.0 version.
```